### PR TITLE
Sticky map alongside theme browser

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -377,6 +377,10 @@
             </form>
           </div>
         @endif
+
+        {{-- Snazzy Maps Themes --}}
+        <flux:separator class="my-6" />
+        <livewire:theme-browser />
       </div>
 
       {{-- RIGHT PANEL: Preview & Code --}}
@@ -429,12 +433,6 @@
           </flux:text>
         </div>
       </div>
-    </div>
-
-    {{-- Snazzy Maps Themes --}}
-    <flux:separator class="my-8" />
-    <div class="max-w-sm">
-      <livewire:theme-browser />
     </div>
 
   </div>


### PR DESCRIPTION
Moves the Snazzy Maps theme browser into the left column so the map preview stays sticky all the way down. Now you can browse and click themes while seeing them apply to the map in real-time without scrolling back up.