### PR TITLE
Fix HeatmapLayer crash after Google removed it in Maps JS API v3.65

### DIFF
--- a/resources/js/map-editor.js
+++ b/resources/js/map-editor.js
@@ -263,7 +263,7 @@ document.addEventListener('alpine:init', () => {
                 '"position":google.maps.ControlPosition.$1');
             // Convert mapTypeControlOptions.style from JSON string to numeric value
             optsJson = optsJson.replace(/"style":(\d+)/g, '"style":$1');
-            const libs = this.heatMapData.length ? '&libraries=visualization' : '';
+            const libs = this.heatMapData.length ? '&v=3.64&libraries=visualization' : '';
             const clusterCdn = this.mapOptions.markerClustering && this.markers.length
                 ? `<script src='https://unpkg.com/@googlemaps/markerclusterer/dist/index.min.js'><\/script>\n`
                 : '';
@@ -672,6 +672,7 @@ document.addEventListener('alpine:init', () => {
 
         heatmapChange() {
             if (!this.mapLoaded) return;
+            if (!google.maps.visualization || !google.maps.visualization.HeatmapLayer) return;
             if (this.heatmap === null) {
                 this.heatmap = new google.maps.visualization.HeatmapLayer([]);
             }
@@ -681,8 +682,14 @@ document.addEventListener('alpine:init', () => {
                 const weight = this.heatMapData[i].weightedLocation.weight;
                 data.push({ location: new google.maps.LatLng(location.lat, location.lng), weight: weight });
             }
-            this.heatmap.setData(data);
-            this.heatmap.setOptions(this.heatmapLayer);
+            const rawHeatmap = Alpine.raw(this.heatmap);
+            rawHeatmap.setData(data);
+            const opts = Alpine.raw(this.heatmapLayer);
+            rawHeatmap.setOptions({
+                dissipating: Boolean(opts.dissipating),
+                opacity: parseFloat(opts.opacity),
+                radius: parseInt(opts.radius, 10),
+            });
         },
 
         maptypeidchanged() {
@@ -1059,11 +1066,13 @@ document.addEventListener('alpine:init', () => {
                 this.updateClustering();
             }
 
-            // Initialize heatmap layer
-            this.heatmap = new google.maps.visualization.HeatmapLayer([]);
-            this.heatmapChange();
-            this.heatmap.setOptions(this.heatmapLayer);
-            this.heatmap.setMap(this.map);
+            // Initialize heatmap layer (only available on v3.64 with visualization library)
+            if (google.maps.visualization && google.maps.visualization.HeatmapLayer) {
+                this.heatmap = new google.maps.visualization.HeatmapLayer([]);
+                this.heatmapChange();
+                this.heatmap.setOptions(this.heatmapLayer);
+                this.heatmap.setMap(this.map);
+            }
 
             // Activate data layers if enabled
             for (const layerType of ['traffic', 'transit', 'bicycling']) {
@@ -1077,7 +1086,6 @@ document.addEventListener('alpine:init', () => {
             google.maps.event.addListener(this.map, 'zoom_changed', () => this.mapzoomed());
             google.maps.event.addListener(this.map, 'maptypeid_changed', () => this.maptypeidchanged());
             google.maps.event.addListener(this.map, 'click', (e) => this.placeMarker(e));
-            google.maps.event.addListener(this.map, 'click', (e) => this.placeHotSpot(e));
         }
     }));
 });

--- a/resources/views/api/mapcode.blade.php
+++ b/resources/views/api/mapcode.blade.php
@@ -1,6 +1,6 @@
 <!-- Google map code from EZ Map - https://ezmap.co -->
 <div id='{{ $map->mapContainer }}'></div>
-<script src='https://maps.googleapis.com/maps/api/js?key={{ $map->apiKey }}{{ $map->heatmap && $map->heatmap->count() ? "&libraries=visualization" : "" }}'></script>
+<script src='https://maps.googleapis.com/maps/api/js?key={{ $map->apiKey }}{{ $map->heatmap && $map->heatmap->count() ? "&v=3.64&libraries=visualization" : "" }}'></script>
 @if(filter_var($map->mapOptions->markerClustering ?? false, FILTER_VALIDATE_BOOLEAN) && $map->markers->count() > 0)
 <script src='https://unpkg.com/@googlemaps/markerclusterer/dist/index.min.js'></script>
 @endif

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -279,7 +279,7 @@
   @vite('resources/js/map-editor.js')
   <script src="https://unpkg.com/@googlemaps/markerclusterer/dist/index.min.js"></script>
   <script async
-    src="https://maps.googleapis.com/maps/api/js?key={{ config('services.google.maps_api_key') }}&libraries=visualization&callback=_mapEditorInitCallback">
+    src="https://maps.googleapis.com/maps/api/js?key={{ config('services.google.maps_api_key') }}{{ $hasMap && $map->heatmap && $map->heatmap->count() ? '&v=3.64&libraries=visualization' : '' }}&callback=_mapEditorInitCallback">
   </script>
   <script>
     // Fallback if Google Maps loads before Alpine

--- a/resources/views/map/show.blade.php
+++ b/resources/views/map/show.blade.php
@@ -6,7 +6,7 @@ if (firstLoad)
 {
   var gmapscript = document.createElement('script');
   gmapscript.id = "ezmap-gmap-script";
-  gmapscript.src = "https://maps.googleapis.com/maps/api/js?key={{ $map->apiKey }}{{ $map->heatmap ? "&libraries=visualization" : "" }}";
+  gmapscript.src = "https://maps.googleapis.com/maps/api/js?key={{ $map->apiKey }}{{ $map->heatmap && $map->heatmap->count() ? "&v=3.64&libraries=visualization" : "" }}";
 
   head.appendChild(gmapscript);
 }

--- a/resources/views/partials/map-settings-panel.blade.php
+++ b/resources/views/partials/map-settings-panel.blade.php
@@ -522,6 +522,7 @@
     </flux:accordion.item>
 
     {{-- ====== HEATMAP ====== --}}
+    <template x-if="heatMapData.length > 0">
     <flux:accordion.item :expanded="$hasHeatmap">
       <flux:accordion.heading>
         <div class="flex items-center gap-2">
@@ -536,7 +537,6 @@
         <div class="space-y-3 py-2">
 
           @php
-            // Google documents removal as "February 2027" only; use the start of the month as an approximate cutoff.
             $heatmapCutoff = now()->setDate(2027, 2, 1)->startOfMonth();
             $heatmapDisabled = now()->gte($heatmapCutoff);
           @endphp
@@ -550,17 +550,18 @@
               </flux:callout.text>
             </flux:callout>
           @else
-            <flux:callout variant="warning" icon="exclamation-triangle">
-              <flux:callout.heading>Heatmap Deprecation Notice</flux:callout.heading>
-              <flux:callout.text>
-                Google is removing the Heatmap Layer from the Maps JavaScript API.
-                This feature will stop working in February 2027.
-                <a href="https://developers.google.com/maps/documentation/javascript/heatmaplayer" target="_blank" class="underline">Learn more</a>
-              </flux:callout.text>
-            </flux:callout>
-
             <template x-if="heatMapData.length > 0">
               <div class="space-y-3">
+                <flux:callout variant="warning" icon="exclamation-triangle">
+                  <flux:callout.heading>Heatmap Deprecation Notice</flux:callout.heading>
+                  <flux:callout.text>
+                    Google has removed the Heatmap Layer from the latest Maps JavaScript API (v3.65+).
+                    Your existing heatmap data is pinned to v3.64 which remains available until February 2027.
+                    Adding new heatmap points is no longer possible.
+                    <a href="https://developers.google.com/maps/documentation/javascript/heatmaplayer" target="_blank" class="underline">Learn more</a>
+                  </flux:callout.text>
+                </flux:callout>
+
                 <flux:subheading>{{ ucwords(EzTrans::translate('heatmapLayerOptions.options', 'heatmap options')) }}</flux:subheading>
                 <div class="grid grid-cols-3 gap-2 items-end">
                   <flux:switch name="heatmapLayer[dissipating]" x-model="heatmapLayer.dissipating" x-on:change="heatmapChange()" label="{{ EzTrans::translate('heatmapLayerOptions.dissipating', 'dissipate') }}" />
@@ -570,16 +571,7 @@
                 <flux:separator />
               </div>
             </template>
-
-            <flux:button variant="primary" size="sm" icon="fire" @click.prevent="addingHotSpot = true">
-              {{ EzTrans::translate('addHotSpot', 'add a hot spot') }}
-            </flux:button>
-
-            <template x-if="addingHotSpot">
-              <flux:callout variant="info" icon="information-circle" class="!py-2 !text-xs">
-                <flux:callout.text>{{ EzTrans::translate('dropHotSpot', "Click the map where you want your hot spot!") }}</flux:callout.text>
-              </flux:callout>
-            </template>
+          @endif
 
             <template x-if="heatMapData.length > 0">
               <div class="space-y-2">
@@ -620,11 +612,11 @@
                 </template>
               </div>
             </template>
-          @endif
 
         </div>
       </flux:accordion.content>
     </flux:accordion.item>
+    </template>
 
   </flux:accordion>
 

--- a/resources/views/partials/textareacode.blade.php
+++ b/resources/views/partials/textareacode.blade.php
@@ -1,5 +1,5 @@
 &lt;!-- Google map code from EZ Map - https://ezmap.co -->
-&lt;script src='https://maps.googleapis.com/maps/api/js?key=@{{ apikey }}@{{ heatMapData ? '&libraries=visualization' : '' }}'>&lt;/script>
+&lt;script src='https://maps.googleapis.com/maps/api/js?key=@{{ apikey }}@{{ heatMapData.length ? '&v=3.64&libraries=visualization' : '' }}'>&lt;/script>
 &lt;script>
   function init() {
     var mapOptions = @{{ mapOptions | json 1 | jsonShrink }};


### PR DESCRIPTION
Google removed `HeatmapLayer` from the Maps JavaScript API in v3.65 (May 2026). This was crashing the map editor on init, preventing all click listeners from registering.

## Changes

- Guard all `HeatmapLayer` usage behind availability checks (no more uncaught errors)
- Pin existing maps with heatmap data to `v=3.64` (available until Feb 2027)
- Remove "add hot spot" button (can no longer add new heatmap points)
- Hide heatmap accordion entirely when map has no heatmap data
- Update deprecation notice to reflect current status
- Remove unconditional `&libraries=visualization` from script tags

## Impact

- Existing maps with heatmap data will continue working via v3.64 until Feb 2027
- All other maps now load the latest API version without the dead visualization library
- The editor no longer crashes on page load